### PR TITLE
added local directory

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -3,15 +3,15 @@ export JAVA_HOME=`/usr/libexec/java_home -v 1.7`
 g++ -arch x86_64 -arch i386 -c \
 -I $JAVA_HOME/include \
 -I $JAVA_HOME/include/darwin \
--F $MYO_HOME \
+-F $MYO_HOME . \
 	com_thalmic_myo_Myo.cpp \
 	com_thalmic_myo_Hub.cpp \
 	handle.cpp \
-	jnidevicelistener.cpp 
+	jnidevicelistener.cpp
 
 g++ -dynamiclib -arch x86_64 -arch i386 \
 -Wl,-rpath,@loader_path \
--F $MYO_HOME -framework myo -framework JavaVM -o libmyo.jnilib \
+-F $MYO_HOME . -framework myo -framework JavaVM -o libmyo.jnilib \
 	com_thalmic_myo_Myo.o \
 	com_thalmic_myo_Hub.o \
 	handle.o \


### PR DESCRIPTION
Hello Nicholas, 

first of all, thank you, I like your work. Yesterday I tried to compile the source to get the `libmyo.jnilib` on Yosemite, too. But the compiler didn't create the first object file `com_thalmic_myo_Myo.o` from the list, because `g++ -F` expects a directory, which will be added. I just added the local directory with a simple dot.

Here you can see the manual for the param `-F` of `g++`:

``` bash
g++ --help | grep "\-F "

-F <value>              Add directory to framework include search path
```

Default version of `g++` (default on Yosemite 10.10):

``` bash
g++ -v

Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 6.0 (clang-600.0.54) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin14.0.0
Thread model: posix
```

Happy coding,
Darius
